### PR TITLE
Remove assets:precompile task rather than running setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,4 @@ RSpec::Core::RakeTask.new if defined?(RSpec)
 
 RuboCop::RakeTask.new if defined?(RuboCop)
 
-task 'assets:precompile' => :setup do
-  puts 'This task is here so that setup runs on heroku'
-  puts 'See: https://github.com/heroku/heroku-buildpack-ruby#flow'
-end
-
 task default: [:rubocop, :spec]


### PR DESCRIPTION
No need to npm install or createdb during the deploy

Closes #31
